### PR TITLE
Introduce design tokens and style guide

### DIFF
--- a/documentation/STYLE_GUIDE.md
+++ b/documentation/STYLE_GUIDE.md
@@ -1,0 +1,37 @@
+# Style Guide
+
+This project uses a small set of design tokens to keep the interface consistent and mobile friendly.
+
+## Colors
+
+| Token | Value |
+|-------|-------|
+| primary | `#6366F1` |
+| secondary | `#EC4899` |
+| accent | `#F59E0B` |
+| success | `#10B981` |
+| error | `#EF4444` |
+| warning | `#FBBF24` |
+| info | `#3B82F6` |
+
+## Fonts
+
+- **sans**: Inter, system-ui, sans-serif
+- **heading**: Poppins, system-ui, sans-serif
+
+## Border Radius
+
+- `xl` – 1rem
+- `2xl` – 1.5rem
+
+These tokens live in `src/lib/design-tokens.ts` and are mirrored in `tailwind.config.js` for Tailwind utility classes.
+
+## Components
+
+### Button
+
+Use the shared `Button` component for actions. It supports `primary`, `secondary`, `accent`, and `ghost` variants and applies the appropriate design tokens for color and focus styles.
+
+### Badge
+
+`Badge` displays small status indicators like points or levels. Variants include `info`, `success`, `warning`, and `error`.

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { cn } from "@/lib/utils"
+
+export type BadgeVariant = "info" | "success" | "warning" | "error"
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant
+}
+
+const variantStyles: Record<BadgeVariant, string> = {
+  info: "bg-info text-white",
+  success: "bg-success text-white",
+  warning: "bg-warning text-white",
+  error: "bg-error text-white",
+}
+
+export const Badge = ({ className, variant = "info", ...props }: BadgeProps) => {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-xl px-2 py-1 text-xs font-medium",
+        variantStyles[variant],
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export default Badge

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { cn } from "@/lib/utils"
+
+export type ButtonVariant = "primary" | "secondary" | "accent" | "ghost"
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+}
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary:
+    "bg-primary text-primary-foreground hover:bg-primary/90 focus:ring-primary",
+  secondary:
+    "bg-secondary text-secondary-foreground hover:bg-secondary/90 focus:ring-secondary",
+  accent:
+    "bg-accent text-accent-foreground hover:bg-accent/90 focus:ring-accent",
+  ghost: "bg-transparent hover:bg-gray-100 text-gray-900 focus:ring-gray-200",
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "primary", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
+          variantStyles[variant],
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export default Button

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,4 @@
+export { Button } from './Button'
+export type { ButtonProps, ButtonVariant } from './Button'
+export { Badge } from './Badge'
+export type { BadgeProps, BadgeVariant } from './Badge'

--- a/src/lib/design-tokens.ts
+++ b/src/lib/design-tokens.ts
@@ -1,0 +1,36 @@
+export const colors = {
+  primary: {
+    DEFAULT: "#6366F1",
+    foreground: "#FFFFFF",
+  },
+  secondary: {
+    DEFAULT: "#EC4899",
+    foreground: "#FFFFFF",
+  },
+  accent: {
+    DEFAULT: "#F59E0B",
+    foreground: "#FFFFFF",
+  },
+  success: "#10B981",
+  error: "#EF4444",
+  warning: "#FBBF24",
+  info: "#3B82F6",
+} as const
+
+export const fonts = {
+  sans: "Inter, system-ui, sans-serif",
+  heading: "Poppins, system-ui, sans-serif",
+} as const
+
+export const radii = {
+  xl: "1rem",
+  xxl: "1.5rem",
+} as const
+
+export const designTokens = {
+  colors,
+  fonts,
+  radii,
+} as const
+
+export type DesignTokens = typeof designTokens

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+import defaultTheme from "tailwindcss/defaultTheme"
 
 export default {
   darkMode: "class",
@@ -6,8 +7,39 @@ export default {
   theme: {
     container: {
       center: true,
+      padding: "1rem",
+      screens: {
+        "2xl": "1400px",
+      },
     },
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#6366F1",
+          foreground: "#FFFFFF",
+        },
+        secondary: {
+          DEFAULT: "#EC4899",
+          foreground: "#FFFFFF",
+        },
+        accent: {
+          DEFAULT: "#F59E0B",
+          foreground: "#FFFFFF",
+        },
+        success: "#10B981",
+        error: "#EF4444",
+        warning: "#FBBF24",
+        info: "#3B82F6",
+      },
+      fontFamily: {
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+        heading: ["Poppins", ...defaultTheme.fontFamily.sans],
+      },
+      borderRadius: {
+        xl: "1rem",
+        "2xl": "1.5rem",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- define color, font, and radius tokens
- extend Tailwind config to expose tokens
- document tokens and badge component in style guide
- add shared Button and Badge components leveraging design tokens
- expand color tokens with warning and info shades

## Testing
- `npm run lint` *(fails: Unexpected any / unused vars)*
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: Missing Firebase configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689c6c87f430832fbaf9638328433d21